### PR TITLE
Add --disable option to disable typeset features

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,22 @@ You can pass an options object to influence how your HTML is typeset:
 ```javascript
 var options = {
   ignore: '.skip, #anything, .which-matches', // string of a CSS selector to skip
-  only: '#only-typeset, .these-elements'    // string of a CSS selector to only apply typeset
+  only: '#only-typeset, .these-elements'    // string of a CSS selector to only apply typeset,
+  disable: ['hyphenate'], // array of features to disable
 };
 ```
+
+##### Disableable features
+
+The following features may be disabled:
+
+- `quotes`
+- `hyphenate`
+- `ligatures`
+- `smallCaps`
+- `punctuation`
+- `hangingPunctuation`
+- `spaces`
 
 ##### CLI Usage
 
@@ -44,6 +57,7 @@ Options:
   -V, --version   output the version number
   -i, --ignore    string of CSS selector(s) to ignore
   -O, --only      string of CSS selector(s) to exclusively apply typeset to
+  --disable,      string of typeset feature(s) to disable, separated by commas
 ```
 
 Examples:
@@ -64,6 +78,12 @@ Use the `--ignore` option to ignore specific CSS selectors:
 
 ```
 $ typeset-js inputFile.html outputFile.html --ignore ".some-class, h3"
+```
+
+Use the `--disable` option to disable typeset features:
+
+```
+$ typeset-js inputFile.html outputFile.html --disable "hyphenate,ligatures"
 ```
 
 CLI redirections:

--- a/src/cmd.js
+++ b/src/cmd.js
@@ -3,6 +3,11 @@ var fs = require('fs');
 var program = require('commander');
 var typeset = require('./index.js');
 
+// Convert comma-separated string into an array of strings
+function list(val) {
+  return val.split(',').map(function(s) { return s.trim(); });
+}
+
 // CLI
 program
   .version(require('../package.json').version)
@@ -13,6 +18,10 @@ program
   ).option(
     '-O, --only <string containing selectors to parse>',
     'string of CSS selector(s) to exclusively apply typeset to'
+  ).option(
+    '--disable <list of typeset feature(s) to disable>',
+    'string of typeset feature(s) to disable, separated by commas',
+    list
   ).parse(process.argv);
 
 var inputFile = program.args[0] || null;
@@ -21,6 +30,7 @@ var outputFile = program.args[1] || null;
 var options = {
   ignore: program.ignore || '',
   only: program.only || '',
+  disable: program.disable || [],
 };
 
 if (inputFile) {

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,12 @@ module.exports = function(html, options){
   options = options || {};
 
   // Pass the HTML to each module
-  for (var i in modules)
-    html = eachTextNode(html, modules[i], options);
+  for (var i in modules) {
+    // Check against disable list only if disable list exists
+    if (options.disable ? options.disable.indexOf(i) == -1 : true) {
+      html = eachTextNode(html, modules[i], options);
+    }
+  }
 
   return html;
 };


### PR DESCRIPTION
Allow users to disable certain typeset features, such as hanging
puncuation or hyphenation.

Conveniently uses Typeset's interal module names to disable these
features. This makes implementation easy, but possibly usage more
difficult (e.g. this patch requires "--disable smallCaps" instead of
allowing "--disable small-caps"). I've listed the feature names in the
README to ease this pain.

Not sure whether it is worth also adding an `--enable` feature.

Fixes #32